### PR TITLE
Add latest node version to travis config docs

### DIFF
--- a/docs/guides-ci-setup.md
+++ b/docs/guides-ci-setup.md
@@ -14,6 +14,8 @@ npm install --save-dev @commitlint/travis-cli
 ```yml
 # travis.yml
 language: node_js
+node_js:
+  - node
 script:
   - commitlint-travis
 ```


### PR DESCRIPTION
The original Travis config does not use high enough version of node so the commitlint does not work. Updated docs accordingly

See this for more info:
https://github.com/conventional-changelog/commitlint/issues/857#issuecomment-554979081